### PR TITLE
Actually mark when we are caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for cached-io
 
+## Unreleased (patch)
+
+- Correctly transition the internal state to `Initializing` when filling the cache for the first time.
+
 ## 1.3.0.0
 
 - **Breaking** Caching functions previously returned `m (t a)`, but it was easy to accidentally use `join` when `m` and `t` were the same monad (eg. `IO (IO a)`), and not get any caching at all. These functions now use a `Cached` newtype for `t a` to make it more difficult to misuse.

--- a/cached-io.cabal
+++ b/cached-io.cabal
@@ -66,3 +66,7 @@ executable test-cachedIO
 
   if flag(developer)
     ghc-options: -Werror
+
+  build-depends:
+    , tasty        ^>=1.5
+    , tasty-hunit  ^>=0.10.0.3

--- a/src/Control/Concurrent/CachedIO.hs
+++ b/src/Control/Concurrent/CachedIO.hs
@@ -12,27 +12,34 @@
 -- * before 10 minutes have passed, it returns the stored value.
 -- * after 10 minutes have passed, it calls @downloadData@ and stores the
 -- result again.
---
-module Control.Concurrent.CachedIO (
-    Cached(..),
+module Control.Concurrent.CachedIO
+  ( Cached (..),
     cachedIO,
     cachedIOWith,
     cachedIO',
-    cachedIOWith'
-    ) where
+    cachedIOWith',
+  )
+where
 
-import Control.Concurrent.STM (atomically, newTVar, readTVar, writeTVar, retry, TVar)
+import Control.Concurrent.STM
+  ( TVar,
+    atomically,
+    newTVarIO,
+    readTVar,
+    retry,
+    writeTVar,
+  )
 import Control.Monad (join)
 import Control.Monad.Catch (MonadCatch, onException)
-import Control.Monad.IO.Class (liftIO, MonadIO)
-import Data.Time.Clock (NominalDiffTime, addUTCTime, getCurrentTime, UTCTime)
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
 
 -- | A cached IO action in some monad @m@. Use 'runCached' to extract the action when you want to query it.
 --
 -- Note that using 'Control.Monad.join' when the cached action and the outer monad are the same will ignore caching.
 newtype Cached m a = Cached {runCached :: m a}
 
-data State a  = Uninitialized | Initializing | Updating a | Fresh UTCTime a
+data State a = Uninitialized | Initializing | Updating a | Fresh UTCTime a
 
 -- | Cache an IO action, producing a version of this IO action that is cached
 -- for 'interval' seconds. The cache begins uninitialized.
@@ -40,10 +47,13 @@ data State a  = Uninitialized | Initializing | Updating a | Fresh UTCTime a
 -- The outer IO is responsible for setting up the cache. Use the inner one to
 -- either get the cached value or refresh, if the cache is older than 'interval'
 -- seconds.
-cachedIO :: (MonadIO m, MonadIO t, MonadCatch t)
-         => NominalDiffTime -- ^ Number of seconds before refreshing cache
-         -> t a             -- ^ IO action to cache
-         -> m (Cached t a)
+cachedIO ::
+  (MonadIO m, MonadIO t, MonadCatch t) =>
+  -- | Number of seconds before refreshing cache
+  NominalDiffTime ->
+  -- | IO action to cache
+  t a ->
+  m (Cached t a)
 cachedIO interval = cachedIOWith (secondsPassed interval)
 
 -- | Cache an IO action, producing a version of this IO action that is cached
@@ -52,61 +62,72 @@ cachedIO interval = cachedIOWith (secondsPassed interval)
 -- The outer IO is responsible for setting up the cache. Use the inner one to
 -- either get the cached value or refresh, if the cache is older than 'interval'
 -- seconds.
-cachedIO' :: (MonadIO m, MonadIO t, MonadCatch t)
-          => NominalDiffTime -- ^ Number of seconds before refreshing cache
-          -> (Maybe (UTCTime, a) -> t a) -- ^ action to cache. The stale value and its refresh date
-          -- are passed so that the action can perform external staleness checks
-          -> m (Cached t a)
+cachedIO' ::
+  (MonadIO m, MonadIO t, MonadCatch t) =>
+  -- | Number of seconds before refreshing cache
+  NominalDiffTime ->
+  -- | action to cache. The stale value and its refresh date
+  -- are passed so that the action can perform external staleness checks
+  (Maybe (UTCTime, a) -> t a) ->
+  m (Cached t a)
 cachedIO' interval = cachedIOWith' (secondsPassed interval)
 
 -- | Check if @starting time@ + @seconds@ is after @end time@
-secondsPassed :: NominalDiffTime  -- ^ Seconds
-               -> UTCTime         -- ^ Start time
-               -> UTCTime         -- ^ End time
-               -> Bool
+secondsPassed ::
+  -- | Seconds
+  NominalDiffTime ->
+  -- | Start time
+  UTCTime ->
+  -- | End time
+  UTCTime ->
+  Bool
 secondsPassed interval start end = addUTCTime interval start > end
 
 -- | Cache an IO action, The cache begins uninitialized.
 --
 -- The outer IO is responsible for setting up the cache. Use the inner one to
 -- either get the cached value or refresh
-cachedIOWith
-    :: (MonadIO m, MonadIO t, MonadCatch t)
-    => (UTCTime -> UTCTime -> Bool) -- ^ Test function:
-    --   If 'isCacheStillFresh' 'lastUpdated' 'now' returns 'True'
-    --   the cache is considered still fresh and returns the cached IO action
-    -> t a -- ^ action to cache.
-    -> m (Cached t a)
+cachedIOWith ::
+  (MonadIO m, MonadIO t, MonadCatch t) =>
+  -- | Test function:
+  -- If @isCacheStillFresh lastUpdated now@ returns 'True',
+  -- the cache is considered still fresh and returns the cached IO action
+  (UTCTime -> UTCTime -> Bool) ->
+  -- | Action to cache.
+  t a ->
+  m (Cached t a)
 cachedIOWith f io = cachedIOWith' f (const io)
 
 -- | Cache an IO action, The cache begins uninitialized.
 --
 -- The outer IO is responsible for setting up the cache. Use the inner one to
 -- either get the cached value or refresh
-cachedIOWith'
-    :: (MonadIO m, MonadIO t, MonadCatch t)
-    => (UTCTime -> UTCTime -> Bool) -- ^ Test function:
-    --   If 'isCacheStillFresh' 'lastUpdated' 'now' returns 'True'
-    --   the cache is considered still fresh and returns the cached IO action
-    -> (Maybe (UTCTime, a) -> t a) -- ^ action to cache. The stale value and its refresh date
-    -- are passed so that the action can perform external staleness checks
-    -> m (Cached t a)
+cachedIOWith' ::
+  (MonadIO m, MonadIO t, MonadCatch t) =>
+  -- | Test function:
+  -- If 'isCacheStillFresh' 'lastUpdated' 'now' returns 'True'
+  -- the cache is considered still fresh and returns the cached IO action
+  (UTCTime -> UTCTime -> Bool) ->
+  -- | Action to cache. The stale value and its refresh date
+  -- are passed so that the action can perform external staleness checks
+  (Maybe (UTCTime, a) -> t a) ->
+  m (Cached t a)
 cachedIOWith' isCacheStillFresh io = do
-  cachedT <- liftIO (atomically (newTVar Uninitialized))
+  cachedT <- liftIO (newTVarIO Uninitialized)
   pure . Cached $ do
     now <- liftIO getCurrentTime
     join . liftIO . atomically $ do
       cached <- readTVar cachedT
       case cached of
         previousState@(Fresh lastUpdated value)
-        -- There's data in the cache and it's recent. Just return.
-          | isCacheStillFresh lastUpdated now -> return (return value)
-        -- There's data in the cache, but it's stale. Update the cache state
-        -- to prevent a second thread from also executing the action. The second
-        -- thread will get the stale data instead.
+          -- There's data in the cache and it's recent. Just return.
+          | isCacheStillFresh lastUpdated now -> pure (pure value)
+          -- There's data in the cache, but it's stale. Update the cache state
+          -- to prevent a second thread from also executing the action. The second
+          -- thread will get the stale data instead.
           | otherwise -> do
-            writeTVar cachedT (Updating value)
-            pure (refreshCache previousState cachedT)
+              writeTVar cachedT (Updating value)
+              pure (refreshCache previousState cachedT)
         -- Another thread is already updating the cache, just return the stale value
         Updating value -> pure (pure value)
         -- The cache is uninitialized. Mark the cache as initializing to block other
@@ -119,11 +140,11 @@ cachedIOWith' isCacheStillFresh io = do
     refreshCache previousState cachedT = do
       let previous = case previousState of
             Fresh lastUpdated value -> Just (lastUpdated, value)
-            _                       -> Nothing
+            _ -> Nothing
       newValue <- io previous `onException` restoreState previousState cachedT
       now <- liftIO getCurrentTime
       liftIO (atomically (writeTVar cachedT (Fresh now newValue)))
-      liftIO (return newValue)
+      liftIO (pure newValue)
 
 restoreState :: (MonadIO m) => State a -> TVar (State a) -> m ()
 restoreState previousState cachedT = liftIO (atomically (writeTVar cachedT previousState))


### PR DESCRIPTION
This fixes a missing state transition (we never marked the internal state as `Initializing`) but I cannot write a test that triggers incorrect behaviour without this patch.