### PR TITLE
Update changelog for config cache builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ## 1.3.2.0
 
 - Add `Functor` instance for `Cached`.
+- Add `cachedIOFromConfig` and `cachedSTMFromConfig` (and a supporting `Config`
+  type), which let the freshness check inspect the cached value in addition to
+  its timestamp.
 
 ## 1.3.1.0
 


### PR DESCRIPTION
These functions were added in 1.3.2.0 but are not mentioned in our CHANGELOG.md. I found this when trying to release 1.4.0.0 to Hackage and were checking if there are any missing changelog entries.