### PR TITLE
chore: dependency update day 2026-06-09

### DIFF
--- a/cached-io.cabal
+++ b/cached-io.cabal
@@ -39,7 +39,7 @@ library
   build-depends:
     , exceptions  >=0.10.4 && <0.11
     , stm         >=2.5    && <2.6
-    , time        >=1.9.3  && <1.16
+    , time        >=1.9.3  && <1.17
 
   hs-source-dirs:   src/
   default-language: Haskell2010

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776127325,
-        "narHash": "sha256-0K6I/yPqeIXloD/RtesnyzrZ6ObTxZqcBXq+v2+w2T8=",
+        "lastModified": 1780979320,
+        "narHash": "sha256-GGdkyUw4drXmBRq8+vPjdVWud91IN/4uckxsMKKo3dI=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "2c0f359c5b8aee71dcb27274895e7547889c4be7",
+        "rev": "8fecf770a0d98bace83448ab4afd48bf2a9698ed",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775585728,
-        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775994940,
-        "narHash": "sha256-z5tkSIdPUs6IG3I9HD2e2stdzOKKh0qDeKkOURYQw6o=",
+        "lastModified": 1780815147,
+        "narHash": "sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9d600cdba342cea3b59aef50e093a547a0f4012f",
+        "rev": "9a681e663d65ff3b0c636df6c7cfbad31e1ed311",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- bump time max version (no breaking changes for us)
- update flake.lock

flake.lock: Update

Flake lock file updates:

• Updated input 'bellroy-nix-foss':
    'github:bellroy/bellroy-nix-foss/2c0f359c5b8aee71dcb27274895e7547889c4be7?narHash=sha256-0K6I/yPqeIXloD/RtesnyzrZ6ObTxZqcBXq%2Bv2%2Bw2T8%3D' (2026-04-14)
  → 'github:bellroy/bellroy-nix-foss/8fecf770a0d98bace83448ab4afd48bf2a9698ed?narHash=sha256-GGdkyUw4drXmBRq8%2BvPjdVWud91IN/4uckxsMKKo3dI%3D' (2026-06-09) • Updated input 'bellroy-nix-foss/git-hooks':
    'github:cachix/git-hooks.nix/580633fa3fe5fc0379905986543fd7495481913d?narHash=sha256-8Psjt%2BTWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4%3D' (2026-04-07)
  → 'github:cachix/git-hooks.nix/61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a?narHash=sha256-kTwur1wV%2B01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs%3D' (2026-05-11) • Updated input 'bellroy-nix-foss/nixpkgs':
    'github:NixOS/nixpkgs/9d600cdba342cea3b59aef50e093a547a0f4012f?narHash=sha256-z5tkSIdPUs6IG3I9HD2e2stdzOKKh0qDeKkOURYQw6o%3D' (2026-04-12)
  → 'github:NixOS/nixpkgs/9a681e663d65ff3b0c636df6c7cfbad31e1ed311?narHash=sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g%3D' (2026-06-07)