### PR TITLE
chore: add support for ghc 9.14

### DIFF
--- a/cached-io.cabal
+++ b/cached-io.cabal
@@ -21,6 +21,7 @@ tested-with:
    || ==9.8.2
    || ==9.10.1
    || ==9.12.1
+   || ==9.14.1
 
 extra-doc-files:
   CHANGELOG.md
@@ -31,7 +32,7 @@ source-repository head
   location: https://github.com/bellroy/haskell-cached-io.git
 
 common deps
-  build-depends: base >=4.13.0.0 && <4.22
+  build-depends: base >=4.13.0.0 && <4.23
 
 library
   import:           deps

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780979320,
-        "narHash": "sha256-GGdkyUw4drXmBRq8+vPjdVWud91IN/4uckxsMKKo3dI=",
+        "lastModified": 1781048285,
+        "narHash": "sha256-w0m2DnFjFe35WcFRIaW/laEMZywCWhrOL/mn8iZxh0g=",
         "owner": "bellroy",
         "repo": "bellroy-nix-foss",
-        "rev": "8fecf770a0d98bace83448ab4afd48bf2a9698ed",
+        "rev": "6e2dd52d93bd3fb08dc4191dc188280b8a5cfd0e",
         "type": "github"
       },
       "original": {
@@ -101,16 +101,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1780815147,
-        "narHash": "sha256-FSDVygpoXrYLH5ZYcqjNkCZzzQrRYZW3awA9vDgb60g=",
+        "lastModified": 1780773863,
+        "narHash": "sha256-t0AXyb11HJHwyRkCed8y15unmgwVlbgcIEVdV1XxYvA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a681e663d65ff3b0c636df6c7cfbad31e1ed311",
+        "rev": "20872773637de0b44f7ac04cde2098db1286e6d5",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixpkgs-25.11-darwin",
+        "ref": "nixpkgs-26.05-darwin",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,8 @@
         "ghc98"
         "ghc910"
         "ghc912"
+        "ghc914"
       ];
-      defaultCompiler = "ghc910";
+      defaultCompiler = "ghc914";
     };
 }


### PR DESCRIPTION
required a bellroy-nix-foss update, and cabal file version bumps, but no code changes; test suite passes